### PR TITLE
Improve Advanced queries notbook

### DIFF
--- a/efd_examples/Advanced_queries.ipynb
+++ b/efd_examples/Advanced_queries.ipynb
@@ -11,6 +11,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Last update: Jun 17 2002\n",
+    "\n",
+    "- Use UTC time scale\n",
+    "- Simplify quoting when executing queries with the efd.influx_client()\n",
+    "- Add a note explaining that chunked queries with chunks that are too small may cause timeouts\n",
+    "\n",
+    "\n",
     "We expect many user needs to be satisfied by the methods provided by the `EfdClient`, but there are situations when using the instance of the `aioinflux` client made by the `EfdClient` constructor directly is advantageous.\n",
     "There are two specific cases that will be explored in this notebook:\n",
     "\n",
@@ -45,8 +52,7 @@
     "import numpy as np\n",
     "\n",
     "from lsst_efd_client import EfdClient\n",
-    "efd = EfdClient('ldf_stable_efd')\n",
-    "cl = efd.influx_client"
+    "efd = EfdClient('ldf_stable_efd')"
    ]
   },
   {
@@ -54,7 +60,7 @@
    "metadata": {},
    "source": [
     "Set up a time window to use in the queries.\n",
-    "Timestamps on EFD topics should be in TAI."
+    "Timestamps on the EFD database are in UTC."
    ]
   },
   {
@@ -63,11 +69,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "t2_agg = Time('2021-03-15T12:00:00', scale='tai')\n",
-    "t1_agg = t2_agg - TimeDelta(5*24*3600, format='sec', scale='tai') # look back over 5 days of data\n",
-    "\n",
-    "t2_chunk = Time('2021-03-04T12:00:00', scale='tai')\n",
-    "t1_chunk = Time('2021-02-04T12:00:00', scale='tai')"
+    "t2 = Time('2022-06-15T12:00:00', scale='utc')\n",
+    "t1 = t2 - TimeDelta(5*24*3600, format='sec') # look back over 5 days of data"
    ]
   },
   {
@@ -91,11 +94,7 @@
     "\n",
     "The time interval in the `GROUP BY time` must be specified as a [duration literal](https://docs.influxdata.com/influxdb/v1.8/query_language/spec/#durations).\n",
     "\n",
-    "➔ Note that influxQL is [picky](https://www.influxdata.com/blog/tldr-influxdb-tech-tips-july-21-2016/) about single vs. double quotes, so if you are getting errors, recheck your quoting.\n",
-    "\n",
-    "➔ Also note that the timestamps in the query indicate the time is in UTC.\n",
-    "The timezone is required by influxQL and though we indicate UTC, the time index in influxDB is actually in TAI.\n",
-    "Since our times are specified in TAI, this should all work even though we are forced to misstate the timezone."
+    "➔ Note that influxQL is [picky](https://www.influxdata.com/blog/tldr-influxdb-tech-tips-july-21-2016/) about single vs. double quotes, so if you are getting errors, recheck your quoting. As rule of thumb, use double quotes arount topic names with special characters like \".\" and \"-\". Always use single quotes around strings (e.g. field values) and timestamps.\n"
    ]
   },
   {
@@ -105,10 +104,10 @@
    "outputs": [],
    "source": [
     "def make_query_str(beg, end, interval):\n",
-    "    return (\"SELECT mean(\\\"ambient_temp\\\") as \\\"temp\\\", mean(\\\"pressure\\\") as \\\"pressure\\\", mean(\\\"humidity\\\") as \\\"humidity\\\" \" +\n",
-    "            \"FROM \\\"efd\\\".\\\"autogen\\\".\\\"lsst.sal.WeatherStation.weather\\\" \" +\n",
-    "            f\"WHERE time > '{beg.isot}Z' and time <= '{end.isot}Z' \" +\n",
-    "            f\"GROUP BY time({interval})\")"
+    "    return (f'''SELECT mean(ambient_temp) AS temp, mean(pressure) AS pressure, mean(humidity) AS humidity\n",
+    "               FROM \"lsst.sal.WeatherStation.weather\" \n",
+    "               WHERE time > '{beg.isot}Z' AND time < '{end.isot}Z'\n",
+    "               GROUP BY time({interval})''')"
    ]
   },
   {
@@ -138,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = await cl.query(make_query_str(t1_agg, t2_agg, '30m'))"
+    "result = await efd.influx_client.query(make_query_str(t1, t2, '30m'))"
    ]
   },
   {
@@ -163,7 +162,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = await cl.query(make_query_str(t1_agg, t2_agg, '6h'))"
+    "result = await efd.influx_client.query(make_query_str(t1, t2, '6h'))"
    ]
   },
   {
@@ -187,13 +186,15 @@
    "metadata": {},
    "source": [
     "At times, the full fidelity data stream is required for processing, but for various reasons fetching all the data at once is impractical.\n",
-    "This is where the [chunked query](https://aioinflux.readthedocs.io/en/stable/usage.html#chunked-responses) functionality of `aioinflux` domes in handy.\n",
+    "This is where the [chunked query](https://aioinflux.readthedocs.io/en/stable/usage.html#chunked-responses) functionality of `aioinflux` comes in handy.\n",
     "Note that chunked queries can also make large queries more reliable as very long queries sometimes get dropped, resulting in an exception.\n",
     "\n",
-    "The simple example here is a demonstration that we have not dropped any weather event for 1 month in early 2021.\n",
+    "In this example we check wether we have recorded all weather events in the EFD in the [t1,t2] time window.\n",
     "\n",
-    "The default chunk size is 1000.\n",
-    "We set it here for demonstration purposes only."
+    "The default chunk size is 1000 records.\n",
+    "We set it here for demonstration purposes only. \n",
+    "\n",
+    "➔ One would expect that the smaller the chunk size the faster the query would return, but that's not always the case. A chunk size too small may cause an overhead in generating too many requests. If you see a timeout error that's probably what is happening. In this case we recommend increasing the chunk size. "
    ]
   },
   {
@@ -202,9 +203,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "query_str = (\"SELECT \\\"private_seqNum\\\" \" +\n",
-    "            \"FROM \\\"efd\\\".\\\"autogen\\\".\\\"lsst.sal.WeatherStation.weather\\\" \" +\n",
-    "            f\"WHERE time > '{t1_chunk.isot}Z' and time <= '{t2_chunk.isot}Z'\")"
+    "query_str = (f'''SELECT private_seqNum \n",
+    "                 FROM \"lsst.sal.WeatherStation.weather\"\n",
+    "                 WHERE time > '{t1.isot}Z' and time <= '{t2.isot}Z' ''')"
    ]
   },
   {
@@ -213,7 +214,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "chunks = await cl.query(query_str, chunked=True, chunk_size=500) # The default chunk size is 1000"
+    "chunks = await efd.influx_client.query(query_str, chunked=True, chunk_size=1000) # The default chunk size is 1000"
    ]
   },
   {
@@ -245,8 +246,16 @@
    "outputs": [],
    "source": [
     "seq_nums = np.array(seq_nums)\n",
-    "diffs = seq_nums[1:] - seq_nums[:-1] - np.ones(len(seq_nums) - 1)\n",
-    "print(f'This should be zero: {diffs.sum()}')"
+    "diff = seq_nums[1:] - seq_nums[:-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.all(diff == 1)"
    ]
   }
  ],
@@ -266,7 +275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Use UTC time scale
- Simplify quoting when executing queries with the `efd.influx_client()`
- Add a note explaining that chunked queries with chunks that are too small may cause timeouts