### PR TITLE
Add UWS job example notebook in experiments

### DIFF
--- a/experiments/ivoa/uws/uws-job-example.ipynb
+++ b/experiments/ivoa/uws/uws-job-example.ipynb
@@ -1,0 +1,193 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "842d69f7-271d-471a-b563-9b1fa94456f8",
+   "metadata": {},
+   "source": [
+    "# Running Async UWS Jobs via the uws-client library"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0481f754-8dd3-4fa8-ae16-a6b4ff68393b",
+   "metadata": {},
+   "source": [
+    "## Install uws-client "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3098b283-d6c4-4ec7-bad3-1a2e4eddffec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install --upgrade --user git+https://github.com/stvoutsin/uws-client.git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67b644e4-74c1-403b-bd55-25b601cfe07d",
+   "metadata": {},
+   "source": [
+    "## Import requirements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae766390-2a58-426b-8b14-a2fa44abb3a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from uwsclient import UWSClient\n",
+    "from uwsclient.models import UWSPhase\n",
+    "from lsst.rsp.utils import get_access_token"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29943970-7de6-43b2-965a-3328cb779afd",
+   "metadata": {},
+   "source": [
+    "## Create client instance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1680e464-38ae-45dc-83c5-64597aca5f25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = UWSClient(\n",
+    "    base_url=\"https://data-dev.lsst.cloud/api/cutout\",\n",
+    "    token=get_access_token()\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6c6eba9-7a1a-414b-ba65-ed473846c95d",
+   "metadata": {},
+   "source": [
+    "## Setup job params"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "def35e35-b6fa-4bfa-8c8b-dfae964c185c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query_params = {\n",
+    "    \"circle\": \"55.7467 -32.2862 0.05\",\n",
+    "    \"id\": \"butler://dp02/20d28216-534a-4102-b8a7-1c7f32a9b78c\"\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f046d140-1508-4305-b49d-aae58cc01fe6",
+   "metadata": {},
+   "source": [
+    "## Create and submit job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08936980-a4a4-4fbf-a0f6-16d2b0ffbe49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_id = client.create_job(query_params)\n",
+    "print(f\"Created job: {job_id}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3a747644-c6bb-4c2a-b1c9-36b0b76c7c48",
+   "metadata": {},
+   "source": [
+    "## Wait for completion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "525d9a3a-4213-44b9-8a0d-e4de5ddc590b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "status = client.wait_for_job_completion(job_id, timeout=300)\n",
+    "print(f\"Final status: {status['phase']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e9a7b89-dcde-4b40-9179-ed22da9c58cf",
+   "metadata": {},
+   "source": [
+    "## Download results if successful"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66cc0526-a8e9-4b2e-8482-31f870084044",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if status['phase'] == UWSPhase.COMPLETED.value:\n",
+    "    results = client.get_job_results(job_id)\n",
+    "    for i, result in enumerate(results):\n",
+    "        if result.get('href'):\n",
+    "            output_path = f\"cutout_result_{i}.fits\"\n",
+    "            client.download_result(result['href'], output_path)\n",
+    "            print(f\"Downloaded result to {output_path}\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0249098f-9ebb-4f80-9274-03fbd8f83750",
+   "metadata": {},
+   "source": [
+    "## Close client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "927bfa9c-6d60-41e3-bf03-cc8256b076bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client.close()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Not sure whether this should be included here or not, but this adds an example notebook which uses the `uws-client` (https://github.com/stvoutsin/uws-client) to run a cutout job via UWS.