### PR TITLE
Add a test for Butler.get()

### DIFF
--- a/butler-get.ipynb
+++ b/butler-get.ipynb
@@ -1,0 +1,71 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fd207629-7936-4897-aebb-63045c0aa687",
+   "metadata": {},
+   "source": [
+    "Many of the tutorial notebooks use `Butler.get()`, but they tend to use a small handful of images.  Due to Butler datastore caching, the other tutorial notebooks often bypass the HTTP download of the images.  This notebook exercises `Butler.get()` with a somewhat randomized set of images to bust the cache.  It also downloads files of multiple dataset types, to ensure that all S3 buckets used to serve DP02 get accessed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57998e82-c41f-422d-879c-7c581baa6fdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import random\n",
+    "import gc\n",
+    "import time\n",
+    "from lsst.daf.butler import Butler\n",
+    "\n",
+    "butler = Butler('dp02', collections='2.2i/runs/DP0.2')\n",
+    "\n",
+    "def test_get(dataset_type):\n",
+    "    refs = butler.query_datasets(dataset_type, find_first=False, limit=100)\n",
+    "    sample = random.sample(refs, 10)\n",
+    "    for r in sample:\n",
+    "        start_time = time.time()\n",
+    "        print(f\"Downloading {r}\")\n",
+    "        butler.get(r)\n",
+    "        end_time = time.time()\n",
+    "        print(f\"...done in {end_time - start_time} seconds\")\n",
+    "        gc.collect()\n",
+    "\n",
+    "test_get(\"raw\")\n",
+    "test_get(\"calexp\")\n",
+    "test_get(\"flat\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9dde55b9-5b3a-4c8a-9955-fc138bc3c50f",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "LSST",
+   "language": "python",
+   "name": "lsst"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add a test that does a variety of calls to Butler.get() for DP02, to give an isolated test of these transfers.  The goal is to avoid the caching that occurs in most tutorial notebooks, and access all the S3 buckets used for serving DP02.