### PR TITLE
Eliminate warnings in butler-get notebook

### DIFF
--- a/butler-get.ipynb
+++ b/butler-get.ipynb
@@ -35,7 +35,7 @@
     "\n",
     "test_get(\"raw\")\n",
     "test_get(\"calexp\")\n",
-    "test_get(\"flat\")"
+    "test_get(\"dark\")"
    ]
   },
   {


### PR DESCRIPTION
Switch the dataset type used for testing the calibration bucket from `flat` to `dark`, because loading `flat` raises warnings with the current version of the science pipelines stack.  For the purposes of this test, all that matters is that we use a calibration dataset type stored in the `rubin-dp02-dp01` S3 bucket at SLAC.