### PR TITLE
DM-51919: Expand the token-info notebook

### DIFF
--- a/token-info.ipynb
+++ b/token-info.ipynb
@@ -4,8 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Retrieve the token from the environment and request information about it.\n",
-    "This calls two token APIs, one to retrieve information about the user identified by the token, and one to retrieve information about the token itself."
+    "Import some useful libraries."
    ]
   },
   {
@@ -14,49 +13,177 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import logging\n",
-    "import os\n",
-    "import time\n",
+    "from datetime import UTC, datetime\n",
     "from urllib.parse import urljoin\n",
     "\n",
-    "import requests\n",
+    "from lsst.rsp import RSPClient, get_access_token"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Obtain the notebook token for the user.\n",
+    "We won't be using this token directly, since we'll instead use an `RSPClient`, but this demonstrates that the standard utility function is working and the user has a token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "token = get_access_token()\n",
+    "assert token, \"You have no notebook token\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Create an RSP client to talk to Gafaelfawr.\n",
+    "Right now, this requires hard-coding the Gafaelfawr API URL prefix.\n",
+    "This interface will change once we have service discovery."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = RSPClient(\"/\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the user's user information from their notebook token."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = await client.get(\"/auth/api/v1/user-info\")\n",
+    "assert r.status_code == 200\n",
+    "user_info = r.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print out information about the user."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Your username is\", user_info[\"username\"])\n",
     "\n",
-    "token = os.getenv('ACCESS_TOKEN', None)\n",
+    "# name and email are optional and may not be set for every user (if, for instance, the RSP uses GitHub\n",
+    "# authentication and the user doesn't release an email address or name).\n",
+    "if \"name\" in user_info:\n",
+    "    print(\"Your name is\", user_info[\"name\"])\n",
+    "if \"email\" in user_info:\n",
+    "    print(\"Your email address is\", user_info[\"email\"])\n",
     "\n",
-    "if token is None:\n",
-    "    logging.fatal('You have no token.')\n",
-    "    \n",
-    "base_url = os.getenv('EXTERNAL_INSTANCE_URL')\n",
-    "user_info_url = urljoin(base_url, '/auth/api/v1/user-info')\n",
-    "r = requests.get(user_info_url, headers={'Authorization': f'bearer {token}'})\n",
-    "data = r.json()\n",
+    "print(\"Your numeric UID is\", user_info[\"uid\"])\n",
+    "print(\"Your numeric GID is\", user_info[\"gid\"])\n",
+    "print(\"Your groups are\", \", \".join(f\"{g['name']} ({g['id']})\" for g in user_info[\"groups\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print out the user's quota information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if \"quota\" not in user_info:\n",
+    "    print(\"You have no quotas set\")\n",
+    "else:\n",
+    "    quota = user_info[\"quota\"]\n",
+    "    if \"api\" in quota:\n",
+    "        print(\"Your API quotas:\")\n",
+    "        for service, amount in sorted(quota[\"api\"].items()):\n",
+    "            print(f\"  Service {service}: {amount} per minute\")\n",
+    "    if \"notebook\" in quota:\n",
+    "        notebook = quota[\"notebook\"]\n",
+    "        if not notebook[\"spawn\"]:\n",
+    "            print(\"You may not create a notebook server\")\n",
+    "        else:\n",
+    "            cpu = quota[\"notebook\"][\"cpu\"]\n",
+    "            memory = quota[\"notebook\"][\"memory\"]\n",
+    "            print(f\"You may create a notebook server with up to {cpu} core equivalents and {memory}GiB of memory\")\n",
+    "    if \"tap\" in quota:\n",
+    "        print(\"Your TAP quotas:\")\n",
+    "        for service, rule in sorted(quota[\"tap\"].items()):\n",
+    "            print(f\"  Backend {service}: {rule['concurrent']} concurrent reqeusts\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, retrieve the metadata about the user's token specifically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "r = await client.get(\"/auth/api/v1/token-info\")\n",
+    "assert r.status_code == 200\n",
+    "token_info = r.json()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display information about the user's token, and check that the token is not expired."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Your username is\", token_info[\"username\"])\n",
+    "print(\"Your token identifier is\", token_info[\"token\"])\n",
+    "print(\"Your token type is\", token_info[\"token_type\"], \"(will always be notebook when executing in Nublado)\")\n",
+    "print(\"Your scopes are\", \", \".join(token_info[\"scopes\"]))\n",
+    "print(\"\")\n",
     "\n",
-    "print(\"Your username is\", data['username'])\n",
-    "print(\"Your name is\", (data.get('name', data['username'])))\n",
-    "print(\"Your numeric UID is\", data['uid'])\n",
+    "# Print out the times.\n",
+    "created = datetime.fromtimestamp(token_info[\"created\"], tz=UTC)\n",
+    "expires = datetime.fromtimestamp(token_info[\"expires\"], tz=UTC)\n",
+    "current = datetime.now(tz=UTC)\n",
+    "print(\"Your token was issued at:\", created.isoformat(sep=\" \"))\n",
+    "print(\"Your token expires at:   \", expires.isoformat(sep=\" \"))\n",
+    "print(\"The time is currently:   \", current.isoformat(sep=\" \", timespec=\"seconds\"))\n",
     "\n",
-    "token_info_url = urljoin(base_url, '/auth/api/v1/token-info')\n",
-    "r = requests.get(token_info_url, headers={'Authorization': f'bearer {token}'})\n",
-    "data = r.json()\n",
+    "assert current >= created, \"Your token was created after the current time?!\"\n",
     "\n",
-    "iat = time.gmtime(int(data['created']))\n",
-    "print(\"Your token was issued at UTC:\", time.asctime(iat))\n",
-    "\n",
-    "exp = time.gmtime(int(data['expires']))\n",
-    "print(\"Your token expires at UTC:   \", time.asctime(exp))\n",
-    "\n",
-    "current_time = time.gmtime()\n",
-    "print(\"The time is currently UTC:   \", time.asctime(current_time))\n",
-    "\n",
-    "if current_time < iat:\n",
-    "    logging.error(\"Your token isn't valid yet.\")\n",
-    "    \n",
-    "if iat < current_time and current_time < exp:\n",
-    "    print(\"Your token is VALID.\")\n",
-    "\n",
-    "if current_time > exp:\n",
-    "    logging.error(\"Your token is expired!\")\n",
-    "    raise RuntimeError(f\"Your token expired at UTC: {time.asctime(exp)}\")"
+    "assert current <= expires, f\"Your token expired at {expires.isoformat(sep=' ')}\"\n",
+    "print(\"Your token is VALID\")"
    ]
   },
   {
@@ -83,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Break the token-info notebook into more step-by-step cells. Use the new RSP client instead of hand-rolling token authentication and URL discovery. Print out all of the information that can be obtained from the Gafaelfawr user-info and token-info endpoints, particularly including the user's quota information.