### PR TITLE
DM-52235: Change search to run_async for DC2_catalog_access.ipynb notebook

### DIFF
--- a/DC2_catalog_access.ipynb
+++ b/DC2_catalog_access.ipynb
@@ -254,7 +254,7 @@
    },
    "outputs": [],
    "source": [
-    "results = service.search(\"SELECT ra, decl FROM dp02_dc2_catalogs.DiaObject WHERE CONTAINS(POINT('ICRS', ra, decl), CIRCLE('ICRS', 60.0, -30.0, 0.05)) = 1\", maxrec=10)\n",
+    "results = service.run_async(\"SELECT ra, decl FROM dp02_dc2_catalogs.DiaObject WHERE CONTAINS(POINT('ICRS', ra, decl), CIRCLE('ICRS', 60.0, -30.0, 0.05)) = 1\", maxrec=10)\n",
     "results.to_table().show_in_notebook()"
    ]
   },
@@ -279,7 +279,7 @@
    },
    "outputs": [],
    "source": [
-    "results = service.search(\"SELECT ra, decl FROM dp02_dc2_catalogs.DiaObject WHERE CONTAINS(POINT('ICRS', ra, decl), POLYGON('ICRS', 60.0, -30.0, 60.05, -30, 60.05, -30.05, 60, -30.05)) = 1\", maxrec=10)\n",
+    "results = service.run_async(\"SELECT ra, decl FROM dp02_dc2_catalogs.DiaObject WHERE CONTAINS(POINT('ICRS', ra, decl), POLYGON('ICRS', 60.0, -30.0, 60.05, -30, 60.05, -30.05, 60, -30.05)) = 1\", maxrec=10)\n",
     "results.to_table().show_in_notebook()"
    ]
   },


### PR DESCRIPTION
Change `search()` to `run_async()` because search uses a sync query and we've set a low timeout for sync queries. This means that mobu may be more likely to run into the timeout and produce an error for what would normally be a successful query when using async.